### PR TITLE
Пустая 3D сцена на Unreal Engine 5 + сборка portable EXE в GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,112 @@
+name: Build Portable Windows EXE
+
+on:
+  push:
+    branches: [ main, "issue-*" ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  PROJECT_NAME: OneTry
+  UE_VERSION: 5.3.2
+
+jobs:
+  package-windows:
+    name: Package Windows Shipping Build
+    # -----------------------------------------------------------------
+    # OPTION A (default): GitHub-hosted Linux runner + Epic's official
+    #   Docker image with cross-compilation to Win64.
+    #
+    #   REQUIREMENT: The repository owner must have their GitHub account
+    #   linked to an Epic Games account that accepted the UE EULA.
+    #   See: https://www.unrealengine.com/en-US/ue-on-github
+    #   Then add a Personal Access Token (classic, read:packages scope)
+    #   as the secret EPIC_GITHUB_TOKEN in repository Settings → Secrets.
+    #
+    # OPTION B: Self-hosted Windows runner (if you have UE5 installed):
+    #   1. Comment out "runs-on: ubuntu-22.04" and the "container:" block.
+    #   2. Uncomment: runs-on: [self-hosted, windows, ue5]
+    #   3. Replace the "Package project" step with the Windows cmd variant
+    #      shown in the comment below that step.
+    # -----------------------------------------------------------------
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/epicgames/unreal-engine:dev-slim-${{ env.UE_VERSION }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.EPIC_GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Verify UE installation
+        run: |
+          UE_ROOT=/home/ue4/UnrealEngine
+          echo "UE root: $UE_ROOT"
+          ls "$UE_ROOT/Engine/Build/BatchFiles/RunUAT.sh"
+
+      - name: Package project (BuildCookRun) - Linux runner
+        # For a self-hosted Windows runner replace this step with:
+        #   shell: cmd
+        #   run: |
+        #     "%UE5_ROOT%\Engine\Build\BatchFiles\RunUAT.bat" ^
+        #       BuildCookRun ^
+        #       -project="%GITHUB_WORKSPACE%\%PROJECT_NAME%.uproject" ^
+        #       -noP4 -platform=Win64 -clientconfig=Shipping ^
+        #       -cook -allmaps -build -stage -pak -archive ^
+        #       -archivedirectory="%GITHUB_WORKSPACE%\PackagedBuild" ^
+        #       -prereqs -nodebuginfo -unattended -utf8output
+        run: |
+          UE_ROOT=/home/ue4/UnrealEngine
+          "$UE_ROOT/Engine/Build/BatchFiles/RunUAT.sh" \
+            BuildCookRun \
+            -project="${GITHUB_WORKSPACE}/${{ env.PROJECT_NAME }}.uproject" \
+            -noP4 \
+            -platform=Win64 \
+            -clientconfig=Shipping \
+            -cook \
+            -allmaps \
+            -build \
+            -stage \
+            -pak \
+            -archive \
+            -archivedirectory="${GITHUB_WORKSPACE}/PackagedBuild" \
+            -prereqs \
+            -nodebuginfo \
+            -unattended \
+            -utf8output \
+            2>&1 | tee uat_log.txt
+        env:
+          CI: true
+
+      - name: List packaged output
+        if: always()
+        run: find PackagedBuild -type f | head -50 || echo "PackagedBuild directory not found"
+
+      - name: Create portable ZIP archive
+        if: success()
+        run: |
+          cd PackagedBuild
+          zip -r "../${{ env.PROJECT_NAME }}-Win64-Shipping.zip" Windows/ \
+            --exclude "*.pdb" --exclude "*.debug"
+
+      - name: Upload portable EXE artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT_NAME }}-Win64-Shipping-${{ github.run_number }}
+          path: ${{ env.PROJECT_NAME }}-Win64-Shipping.zip
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Upload UAT log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uat-log-${{ github.run_number }}
+          path: uat_log.txt
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Unreal Engine generated directories
+Binaries/
+Build/
+DerivedDataCache/
+Intermediate/
+Saved/
+
+# Visual Studio
+*.VC.db
+*.opensdf
+*.opendb
+*.sdf
+*.sln
+*.suo
+
+# Xcode
+*.xcworkspace
+*.xcodeproj
+
+# IDE
+.idea/
+.vs/
+
+# Unreal editor content collections
+Content/Collections/
+Content/__ExternalActors__/
+Content/__ExternalObjects__/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T10:59:46.148Z for PR creation at branch issue-2-b0c3b57a666f for issue https://github.com/Jhon-Crow/One-try/issues/2

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T10:59:46.148Z for PR creation at branch issue-2-b0c3b57a666f for issue https://github.com/Jhon-Crow/One-try/issues/2

--- a/Config/DefaultEditor.ini
+++ b/Config/DefaultEditor.ini
@@ -1,0 +1,2 @@
+[/Script/UnrealEd.EditorLoadingSavingSettings]
+bMonitorContentDirectories=False

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -1,0 +1,14 @@
+[/Script/EngineSettings.GameMapsSettings]
+EditorStartupMap=/Engine/Maps/Templates/Template_Default
+GameDefaultMap=/Engine/Maps/Templates/Template_Default
+TransitionMap=/Engine/Maps/Templates/Template_Default
+
+[/Script/Engine.Engine]
++ActiveGameNameRedirects=(OldGameName="TP_Blank",NewGameName="/Script/OneTry")
++ActiveGameNameRedirects=(OldGameName="/Script/TP_Blank",NewGameName="/Script/OneTry")
+
+[/Script/HardwareTargeting.HardwareTargetingSettings]
+TargetedHardwareClass=Desktop
+AppliedTargetedHardwareClass=Desktop
+DefaultGraphicsPerformance=Maximum
+AppliedDefaultGraphicsPerformance=Maximum

--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -1,0 +1,6 @@
+[/Script/EngineSettings.GeneralProjectSettings]
+ProjectName=OneTry
+ProjectVersion=1.0
+CompanyName=
+CopyrightNotice=
+Description=Empty 3D scene

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -1,0 +1,8 @@
+[/Script/Engine.InputSettings]
++AxisMappings=(AxisName="MoveForward",Scale=1.000000,Key=W)
++AxisMappings=(AxisName="MoveForward",Scale=-1.000000,Key=S)
++AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=D)
++AxisMappings=(AxisName="MoveRight",Scale=-1.000000,Key=A)
++AxisMappings=(AxisName="Turn",Scale=1.000000,Key=MouseX)
++AxisMappings=(AxisName="LookUp",Scale=-1.000000,Key=MouseY)
++ActionMappings=(ActionName="Jump",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=SpaceBar)

--- a/OneTry.uproject
+++ b/OneTry.uproject
@@ -1,0 +1,16 @@
+{
+    "FileVersion": 3,
+    "EngineAssociation": "5.3",
+    "Category": "",
+    "Description": "Empty 3D scene project",
+    "Modules": [],
+    "Plugins": [
+        {
+            "Name": "ModelingToolsEditorMode",
+            "Enabled": true,
+            "TargetAllowList": [
+                "Editor"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # One-try
+
+Empty 3D scene project built with Unreal Engine 5.
+
+## Requirements
+
+- Unreal Engine 5.3 (download from [Epic Games Launcher](https://www.unrealengine.com/))
+
+## Opening the project
+
+1. Install Unreal Engine 5.3 via Epic Games Launcher.
+2. Double-click `OneTry.uproject` to open in the editor.
+
+## GitHub Actions — Portable Windows EXE
+
+The workflow `.github/workflows/build.yml` packages a portable Windows EXE on every push.
+
+### Setup (required once)
+
+The build uses Epic's official Docker image (`ghcr.io/epicgames/unreal-engine`), which requires:
+
+1. Link your GitHub account to an Epic Games account:
+   - Go to [unrealengine.com](https://www.unrealengine.com/) → account → **Connected Accounts** → connect GitHub.
+   - Accept the `EpicGames/UnrealEngine` repository invitation (sent via email).
+2. Create a GitHub Personal Access Token (classic) with the `read:packages` scope.
+3. Add it as a repository secret named **`EPIC_GITHUB_TOKEN`**:
+   - Repository → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**.
+
+### Running the build
+
+- Trigger automatically on push/PR, or manually via **Actions** → **Build Portable Windows EXE** → **Run workflow**.
+- Download the ZIP artifact from the workflow run summary. Extract and run `OneTry.exe` — no installation required.
+
+### Alternative: Self-hosted Windows runner
+
+If you have a Windows machine with UE5 installed, follow the comments in `build.yml` to switch to a self-hosted runner (no Epic GitHub token needed).


### PR DESCRIPTION
## Решение / Solution

Fixes Jhon-Crow/One-try#2

### Что сделано / What was done

**Пустая 3D сцена (Unreal Engine 5.3, blueprint-only):**
- `OneTry.uproject` — файл проекта UE5, без C++ модулей (blueprint-only)
- `Config/DefaultEngine.ini` — использует встроенную пустую 3D карту движка (`/Engine/Maps/Templates/Template_Default`)
- `Config/DefaultGame.ini`, `Config/DefaultInput.ini`, `Config/DefaultEditor.ini` — стандартные настройки

**Сборка portable EXE в GitHub Actions:**
- `.github/workflows/build.yml` — упаковывает Windows Shipping EXE через UnrealAutomationTool (`BuildCookRun`)
- Результат загружается как артефакт (ZIP-архив) — скачать и запустить без установки
- Использует официальный Docker-образ Epic Games (`ghcr.io/epicgames/unreal-engine`)

### Как запустить сборку / How to trigger the build

1. **Требуется один раз:** привязать GitHub-аккаунт к Epic Games и добавить секрет `EPIC_GITHUB_TOKEN` (инструкции в README)
2. Сборка запускается автоматически при push/PR, или вручную: **Actions → Build Portable Windows EXE → Run workflow**
3. Скачать ZIP-артефакт из результатов сборки → распаковать → запустить `OneTry.exe`

Альтернатива: self-hosted Windows runner с установленным UE5 (см. комментарии в `build.yml`).

### Структура проекта / Project structure

```
OneTry.uproject          # UE5 project descriptor (blueprint-only)
Config/
  DefaultEngine.ini      # maps to built-in empty 3D template map
  DefaultGame.ini
  DefaultInput.ini
  DefaultEditor.ini
Content/Maps/            # ready for custom .umap files
.github/workflows/
  build.yml              # GitHub Actions: package Win64 portable EXE
.gitignore               # excludes Binaries/, Intermediate/, Saved/
README.md                # setup instructions
```

### UAT flags used

`-platform=Win64 -clientconfig=Shipping -cook -allmaps -build -stage -pak -archive -prereqs -nodebuginfo`